### PR TITLE
Removed all inline styling if false is passed to colorTheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const MyComponent = ({ handleLogin, box, ethereum, myAddress, currentUser3BoxPro
 | `agentProfile`    | Object       |  { chatName: 'Chatbox', imageUrl: null }   | Optional    | An object with the name of the chatbox which will appear in the `Join thread` step and in the header of the chat UI.  The default `imageUrl` is the provided chat icon. |
 | `spaceOpts`    | Object       | | Optional    | Optional parameters for threads (see [Docs.3box.io](https://Docs.3box.io) for more info)|
 | `threadOpts`    | Object       | | Optional    | Optional parameters for threads (see [Docs.3box.io](https://Docs.3box.io) for more info)|
-| `colorTheme`    | String       |  False  | Optional    | Pass an rgb or hex color string to match the color theme of your application |
+| `colorTheme`    | String/Boolean       |  False  | Optional    | Pass an rgb or hex color string to match the color theme of your application |
 | `mute`    | Boolean       |  False  | Optional    | Pass false to turn off sound for incoming messages. |
 | `showEmoji`    | Boolean       |  False  | Optional    | Pass false to turn off the emoji pop up within the chat input UI. |
 | `currentUser3BoxProfile`    | Object       |   | Optional    | If the current user has already had their 3Box data fetched at the global dApp state, pass the object returned from `Box.getProfile(profileAddress)` to avoid an extra request.  This data will be rendered in the Chatbox input interface.|

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ interface ChatBoxProps {
   showEmoji?: boolean;
   openOnMount?: boolean;
 
-  colorTheme: string;
+  colorTheme?: string|boolean;
   currentUserAddr?: string;
 
   agentProfile: {

--- a/src/ChatBox.jsx
+++ b/src/ChatBox.jsx
@@ -37,7 +37,7 @@ class ChatBox extends Component {
         chatName: 'Chatbox',
         imageUrl: null
       },
-      colorTheme: colorTheme || '#181F21',
+      colorTheme: colorTheme,
       showEmoji,
       popupChat,
       isOpen: checkIsMobileDevice() ? false : openOnMount,
@@ -333,7 +333,7 @@ class ChatBox extends Component {
 
 ChatBox.propTypes = {
   chatName: PropTypes.string,
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   popupChat: PropTypes.bool,
   openOnMount: PropTypes.bool,
   mute: PropTypes.bool,

--- a/src/components/ChatWindow.jsx
+++ b/src/components/ChatWindow.jsx
@@ -130,7 +130,7 @@ ChatWindow.propTypes = {
   isJoiningThread: PropTypes.bool,
   currentUser3BoxProfile: PropTypes.object,
   currentUserAddr: PropTypes.string,
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   profiles: PropTypes.object,
   popupChat: PropTypes.bool,
   messageList: PropTypes.array,

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -26,7 +26,7 @@ class Header extends Component {
     const url = userProfileURL ? userProfileURL(currentUserAddr) : `https://3box.io/login?wallet=${getCurrentProvider(ethereum)}`;
 
     return (
-      <div className="sc-header" style={{ backgroundColor: colorTheme }}>
+      <div className="sc-header" style={colorTheme ? { backgroundColor: colorTheme } : {}}>
         <div className="sc-header_details">
           {imageUrl ? <img className="sc-header--img" src={imageUrl} alt="Chat Profile" />
             : <SVG src={Chat} alt="Logo" className="sc-header--img default" />
@@ -70,7 +70,7 @@ class Header extends Component {
 Header.propTypes = {
   imageUrl: PropTypes.string,
   chatName: PropTypes.string,
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   currentUserAddr: PropTypes.string,
   onClose: PropTypes.func,
   membersOnlineLength: PropTypes.number,

--- a/src/components/Launcher.jsx
+++ b/src/components/Launcher.jsx
@@ -61,7 +61,7 @@ class Launcher extends Component {
         <div
           className={classList.join(' ')}
           onClick={this.handleClick.bind(this)}
-          style={{ backgroundColor: colorTheme }}
+          style={colorTheme ? { backgroundColor: colorTheme } : {}}
         >
           {(newMessagesCount !== 0 && isOpen === false) && <div className={'sc-new-messages-count'}> {newMessagesCount} </div>}
           <SVG className="sc-open-icon" src={launcherIconActive} />
@@ -113,7 +113,7 @@ Launcher.propTypes = {
   popupChat: PropTypes.bool,
   noWeb3: PropTypes.bool,
   currentUserAddr: PropTypes.string,
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   agentProfile: PropTypes.object,
   currentUser3BoxProfile: PropTypes.object,
   profiles: PropTypes.object,

--- a/src/components/LoadingAnimation.js
+++ b/src/components/LoadingAnimation.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import '../styles/LoadingAnimation.scss';
 
 const LoadingAnimation = ({ colorTheme, threadLoading }) => (
-  <div style={{ color: colorTheme }} className={`la-ball-pulse-sync ${threadLoading ? 'threadLoading' : ''}`}>
+  <div style={colorTheme ? { color: colorTheme } : {}} className={`la-ball-pulse-sync ${threadLoading ? 'threadLoading' : ''}`}>
     <div></div>
     <div></div>
     <div></div>
@@ -13,7 +13,7 @@ const LoadingAnimation = ({ colorTheme, threadLoading }) => (
 )
 
 LoadingAnimation.propTypes = {
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   threadLoading: PropTypes.bool
 };
 

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -137,7 +137,7 @@ MessageList.propTypes = {
   membersOnline: PropTypes.array,
   profiles: PropTypes.object,
   currentUserAddr: PropTypes.string,
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   userProfileURL: PropTypes.func,
   handleShowOnlineList: PropTypes.func.isRequired,
   isShowOnlineList: PropTypes.bool,

--- a/src/components/Messages/TextMessage.js
+++ b/src/components/Messages/TextMessage.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 const TextMessage = ({ isMyComment, colorTheme, messageObj }) => (
   <div
     className="sc-message--text"
-    style={{ backgroundColor: isMyComment ? colorTheme : '#ececec'}}
+    style={{ backgroundColor: isMyComment && colorTheme ? colorTheme : {}}}
   >
     <Linkify properties={{ target: '_blank' }}>
       {messageObj.message}
@@ -15,7 +15,7 @@ const TextMessage = ({ isMyComment, colorTheme, messageObj }) => (
 
 TextMessage.propTypes = {
   isMyComment: PropTypes.bool,
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   messageObj: PropTypes.object,
 };
 

--- a/src/components/Messages/index.js
+++ b/src/components/Messages/index.js
@@ -99,7 +99,7 @@ Message.propTypes = {
   profile: PropTypes.object,
   likers: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
   isFirstMessage: PropTypes.bool,
-  colorTheme: PropTypes.string,
+  colorTheme: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   membersOnline: PropTypes.array,
   currentUserAddr: PropTypes.string,
   userProfileURL: PropTypes.func,

--- a/src/styles/message.scss
+++ b/src/styles/message.scss
@@ -21,6 +21,10 @@
 
 .sc-message--content.sent {
   justify-content: flex-end;
+
+  .sc-message--text {
+    background-color: $threeBoxBlack;
+  }
 }
 
 .sc-message--content.sent .sc-message--avatar {
@@ -70,6 +74,7 @@
 }
 
 .sc-message--content.received .sc-message--text {
+  background-color: $defaultReceivedBubbleColor;
   color: #263238;
   margin-right: 40px;
 }
@@ -151,7 +156,7 @@
   display: none;
   background-color: white;
   border: 1px solid $borderColor;
-  z-index: 5;
+  z-index: 1;
   border-radius: 12px;
   min-height: 23px;
   min-width: 24px;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -8,6 +8,8 @@ $windowBorderRadius: 14px;
 $threeBoxBlack: #181F21;
 $threeBoxBlackHover: rgb(47, 56, 58);
 
+$defaultReceivedBubbleColor: #ECECEC;
+
 $maxCommentWidth: 600px;
 $minCommentWidth: 300px;
 


### PR DESCRIPTION
The purpose of this commit is to remove all of the inline styling (example: style="background-color: red/whatever;") that's being needlessly added by the prop `colorTheme`.

As specified in your own documentation, colorTheme should be either a string or a false value. The later one should be the default. However, even if I don't set a style, the component needlessly adds a color and background color to a few elements, making it hard to override those colors and I would say it's impossible unless we use the tag `!important`, which many consider to be a bad tag to use.

This commit solves this issue by allowing the component to either not specify the tag at all or specify its value as `false`. I've tested the example project and and it is not breaking anything but I highly encourage you to test it as well. The component is being styled as it should if nothing is passed and no inline styles are being added needlessly.

Note regarding theming: not sure if you are ever going to introduce things like light/dark themes, but the approach we're currently implementing for Augur's themes is basically adding CSS variables inside a CSS' :root {}, which allows us to switch themes on the fly, without the need for the project to re-compile. Root is the `<html>` element and it has a theme tag, like `<html theme="dark">`. Example of the CSS:
```css
:root[theme="light"] {
  --default-color: black;
  --default-background: white;
}

:root[theme="dark"] {
  --default-color: white;
  --default-background: black;
}

.text-baloon {
  color: --default-color;
  background-color: --default-background;
}
```
A helper function sets the theme in the `<html>` element and the whole thing gets styled with the chosen theme.